### PR TITLE
ASDPLNG-124: Use sshd::allow_from for qualys access

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -48,6 +48,7 @@ The following parameters are available in the `profile_audit::qualys` class:
 * [`ip`](#ip)
 * [`ssh_authorized_key`](#ssh_authorized_key)
 * [`ssh_authorized_key_type`](#ssh_authorized_key_type)
+* [`sshd_custom_cfg`](#sshd_custom_cfg)
 * [`uid`](#uid)
 * [`user`](#user)
 * [`user_comment`](#user_comment)
@@ -93,6 +94,12 @@ String of the public ssh authorized key that the qualys user uses for authentica
 Data type: `String`
 
 String of the key type used for the qualys user's authentication
+
+##### <a name="sshd_custom_cfg"></a>`sshd_custom_cfg`
+
+Data type: `Hash`
+
+Hash of additional sshd match parameters for matchblock for qualys access
 
 ##### <a name="uid"></a>`uid`
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -6,6 +6,13 @@ profile_audit::qualys::homedir: "/home/qualys"
 profile_audit::qualys::ip: "141.142.148.51"
 profile_audit::qualys::ssh_authorized_key: null
 profile_audit::qualys::ssh_authorized_key_type: "rsa"
+profile_audit::qualys::sshd_custom_cfg:
+  PubkeyAuthentication: "yes"
+  AuthenticationMethods: "publickey"
+  Banner: "none"
+  MaxAuthTries: "6"
+  MaxSessions: "10"
+  X11Forwarding: "no"
 profile_audit::qualys::uid: "19999"
 profile_audit::qualys::user: "qualys"
 profile_audit::qualys::user_comment: "NCSA IRST Qualys - security@ncsa.illinois.edu"


### PR DESCRIPTION
See https://jira.ncsa.illinois.edu/browse/ASDPLNG-124

This is currently being tested on `asd-test-rhel8a` & `asd-test-centos7a`.

fyi: This surfaced a couple of bugs in the ncsa/sshd Puppet module, so watch for a PR for https://github.com/ncsa/puppet-sshd as well.