### PR TITLE
Skip empty lines

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -61,6 +61,7 @@ profile_audit::root_equivalence::files:
           openlog("k5login_audit", 0, "LOG_LOCAL0") or die "Cannot open log";
           while (<K5LOGIN>) {
               if ($_ =~ /^\s*#/) { next; }
+              if ($_ =~ /^\s*$/) { next; }
               syslog("info", $_);
           }
           closelog();


### PR DESCRIPTION
Prevent empty lines in .k5login from being sent to syslog