### PR TITLE
SVCPLAN-2325: Issues with qualys ssh_authorized_key when homedir...

### DIFF
--- a/manifests/qualys.pp
+++ b/manifests/qualys.pp
@@ -97,25 +97,16 @@ class profile_audit::qualys (
       $homedir:
         ensure => 'directory',
         mode   => '0700',
-      ;
-      "${homedir}/.ssh":
-        ensure => 'directory',
-        mode   => '0700',
-      ;
-      "${homedir}/.ssh/authorized_keys":
-        ensure => 'present',
-        mode   => '0600',
-      ;
-      default:
-        owner => $user,
-        group => $group,
+        owner  => $user,
+        group  => $group,
       ;
     }
 
     ssh_authorized_key { $user:
-      user => $user,
-      key  => $ssh_authorized_key,
-      type => $ssh_authorized_key_type,
+      user    =>    $user,
+      key     =>    $ssh_authorized_key,
+      type    =>    $ssh_authorized_key_type,
+      require => File[ $homedir ]
     }
 
     ::sshd::allow_from{ 'sshd allow qualys from qualys appliance':


### PR DESCRIPTION
…is in remote filesystem

This change is needed when qualys' homedir is in GPFS.

This has been tested on `mforgehn9`, `control-test-rhel7a`, & `control-test-rhel8a`.