### PR TITLE
SVCPLAN-2112: Remove qualys from subgid & subuid files

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -118,6 +118,8 @@ The following parameters are available in the `profile_audit::qualys` class:
 * [`ssh_authorized_key`](#ssh_authorized_key)
 * [`ssh_authorized_key_type`](#ssh_authorized_key_type)
 * [`sshd_custom_cfg`](#sshd_custom_cfg)
+* [`subgid_file`](#subgid_file)
+* [`subuid_file`](#subuid_file)
 * [`uid`](#uid)
 * [`user`](#user)
 * [`user_comment`](#user_comment)
@@ -181,6 +183,18 @@ String of the key type used for the qualys user's authentication
 Data type: `Hash`
 
 Hash of additional sshd match parameters for matchblock for qualys access
+
+##### <a name="subgid_file"></a>`subgid_file`
+
+Data type: `String`
+
+Path to subgid file if supported by OS
+
+##### <a name="subuid_file"></a>`subuid_file`
+
+Data type: `String`
+
+Path to subuid file if supported by OS
 
 ##### <a name="uid"></a>`uid`
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -26,6 +26,8 @@ profile_audit::qualys::sshd_custom_cfg:
   MaxAuthTries: "6"
   MaxSessions: "10"
   X11Forwarding: "no"
+profile_audit::qualys::subgid_file: ""
+profile_audit::qualys::subuid_file: ""
 profile_audit::qualys::uid: "19999"
 profile_audit::qualys::user: "qualys"
 profile_audit::qualys::user_comment: "NCSA IRST Qualys - security@ncsa.illinois.edu"

--- a/data/os/RedHat.yaml
+++ b/data/os/RedHat.yaml
@@ -3,3 +3,6 @@ profile_audit::root_equivalence::packages:
   - "perl"
   - "perl-File-HomeDir"
   - "perl-Sys-Syslog"
+
+profile_audit::qualys::subgid_file: "/etc/subgid"
+profile_audit::qualys::subuid_file: "/etc/subuid"

--- a/manifests/qualys.pp
+++ b/manifests/qualys.pp
@@ -32,6 +32,12 @@
 # @param sshd_custom_cfg
 #   Hash of additional sshd match parameters for matchblock for qualys access
 #
+# @param subgid_file
+#   Path to subgid file if supported by OS
+#
+# @param subuid_file
+#   Path to subuid file if supported by OS
+#
 # @param uid
 #   String of the UID of the local qualys user
 #
@@ -55,6 +61,8 @@ class profile_audit::qualys (
   Optional[ String ] $ssh_authorized_key,
   String             $ssh_authorized_key_type,
   Hash               $sshd_custom_cfg,
+  String             $subgid_file,
+  String             $subuid_file,
   String             $uid,
   String             $user,
   String             $user_comment,
@@ -91,6 +99,22 @@ class profile_audit::qualys (
       purge_ssh_keys => true,
       shell          => '/bin/bash',
       uid            => $uid,
+    }
+
+    if ( ! empty($subgid_file) and ! empty($subuid_file) ) {
+      # CLEAN UP qualys subuid/subgid FILE ENTRIES
+      File_line {
+        ensure            => 'absent',
+        match_for_absence => true,
+      }
+      file_line { "remove ${group} group from ${subgid_file}":
+        path  => $subgid_file,
+        match => "^${group}:*",
+      }
+      file_line { "remove ${user} user from ${subuid_file}":
+        path  => $subuid_file,
+        match => "^${user}:*",
+      }
     }
 
     file {


### PR DESCRIPTION
Fix #21 

See https://jira.ncsa.illinois.edu/browse/SVCPLAN-2112

This is being tested on:
- `control-test-centos7a`
- `control-test-rhel7a`
- `control-test-rhel8a`
- `control-test-rhel9a`