### PR TITLE
SVCPLAN-2290 SECURITY-1586 Expand Qualys IPs

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -16,7 +16,7 @@ profile_audit::qualys::escalated_scan_sudocfg: |
 profile_audit::qualys::gid: "19999"
 profile_audit::qualys::group: "qualys"
 profile_audit::qualys::homedir: "/home/qualys"
-profile_audit::qualys::ip: "141.142.148.51"
+profile_audit::qualys::ip: "141.142.148.48/29"
 profile_audit::qualys::ssh_authorized_key: null
 profile_audit::qualys::ssh_authorized_key_type: "rsa"
 profile_audit::qualys::sshd_custom_cfg:


### PR DESCRIPTION
Setup default value for profile_audit::qualys::ip to use a CIDR that includes all qualys appliances instead of just one

This change will update access.conf and match blocks in sshd_config, which do not clean up after themselves. If you have stateful nodes, or stateless nodes that you don't plan on rebooting close to the time you update to this module version, you should plan on manually cleaning up those files. The old value (if you have not overridden it) was 141.142.148.51