### PR TITLE
SVCPLAN-8386: fix Qualys ID issue

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -113,7 +113,6 @@ The following parameters are available in the `profile_audit::qualys` class:
 * [`enabled`](#-profile_audit--qualys--enabled)
 * [`escalated_scans`](#-profile_audit--qualys--escalated_scans)
 * [`escalated_scan_sudocfg`](#-profile_audit--qualys--escalated_scan_sudocfg)
-* [`gid`](#-profile_audit--qualys--gid)
 * [`group`](#-profile_audit--qualys--group)
 * [`homedir`](#-profile_audit--qualys--homedir)
 * [`ip`](#-profile_audit--qualys--ip)
@@ -143,12 +142,6 @@ Boolean to define if qualys should be allowed to sudo to root for escalated scan
 Data type: `String`
 
 String setting qualys sudo config
-
-##### <a name="-profile_audit--qualys--gid"></a>`gid`
-
-Data type: `String`
-
-String of the GID of the local qualys user
 
 ##### <a name="-profile_audit--qualys--group"></a>`group`
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -13,7 +13,6 @@ profile_audit::qualys::escalated_scan_sudocfg: |
   Defaults:qualys !requiretty
   %qualys ALL=(ALL) NOPASSWD: NOMAIL: ALL
   qualys ALL=(ALL) NOPASSWD: NOMAIL: ALL
-profile_audit::qualys::gid: "19999"
 profile_audit::qualys::group: "qualys"
 profile_audit::qualys::homedir: "/home/qualys"
 profile_audit::qualys::ip: "141.142.148.48/29"
@@ -28,7 +27,7 @@ profile_audit::qualys::sshd_custom_cfg:
   X11Forwarding: "no"
 profile_audit::qualys::subgid_file: ""
 profile_audit::qualys::subuid_file: ""
-profile_audit::qualys::uid: "19999"
+profile_audit::qualys::uid: "1125"
 profile_audit::qualys::user: "qualys"
 profile_audit::qualys::user_comment: "NCSA IRST Qualys - security@ncsa.illinois.edu"
 

--- a/manifests/qualys.pp
+++ b/manifests/qualys.pp
@@ -11,9 +11,6 @@
 # @param escalated_scan_sudocfg
 #   String setting qualys sudo config
 #
-# @param gid
-#   String of the GID of the local qualys user
-#
 # @param group
 #   String of the group name of the local qualys user
 #
@@ -51,21 +48,20 @@
 #   include profile_audit::qualys
 #
 class profile_audit::qualys (
-  Boolean            $enabled,
-  Boolean            $escalated_scans,
-  String             $escalated_scan_sudocfg,
-  String             $gid,
-  String             $group,
-  String             $homedir,
-  String             $ip,
+  Boolean          $enabled,
+  Boolean          $escalated_scans,
+  String           $escalated_scan_sudocfg,
+  String           $group,
+  String           $homedir,
+  String           $ip,
   Optional[String] $ssh_authorized_key,
-  String             $ssh_authorized_key_type,
-  Hash               $sshd_custom_cfg,
-  String             $subgid_file,
-  String             $subuid_file,
-  String             $uid,
-  String             $user,
-  String             $user_comment,
+  String           $ssh_authorized_key_type,
+  Hash             $sshd_custom_cfg,
+  String           $subgid_file,
+  String           $subuid_file,
+  String           $uid,
+  String           $user,
+  String           $user_comment,
 ) {
   # ONLY SETUP If enabled AND A ssh_authorized_key IS PROVIDED FOR QUALYS USER
   if ( $enabled and ! $ssh_authorized_key ) {
@@ -78,17 +74,26 @@ class profile_audit::qualys (
     }
   }
   elsif ( $enabled and $ssh_authorized_key ) {
+    # we are moving away from GID 19999 for the qualys group, so correct that
+    exec { 'groupdel if gid 19999':
+      command => "groupdel -f ${group}",
+      onlyif  => "getent group -s compat ${group} | grep -q ':19999'",
+      path    => ['/usr/bin', '/usr/sbin', '/sbin'],
+      before  => Group[$group],
+    }
+
+    # create qualys as a system group (let the OS pick the GID)
     group { $group:
       ensure => 'present',
       name   => $group,
-      gid    => $gid,
+      system => true,
     }
 
     user { $user:
       ensure         => 'present',
       name           => $user,
       comment        => $user_comment,
-      gid            => $gid,
+      gid            => $group,
       home           => $homedir,
       managehome     => true,
       password       => '!!',
@@ -138,6 +143,24 @@ class profile_audit::qualys (
       key     => $ssh_authorized_key,
       type    => $ssh_authorized_key_type,
       require => File[$homedir],
+    }
+
+    # if the qualys UID or qualys GID changes, we need to chown
+    exec { 'chown_if_id_change':
+      command     => "chown -R ${user}:${group} ${homedir}",
+      refreshonly => true,
+      path        => ['/usr/bin', '/usr/sbin', '/sbin'],
+      timeout     => 300,
+      subscribe   => [
+        User[$user],
+        Group[$group],
+      ],
+      require     => [
+        Group[$group],
+        User[$user],
+        File[$homedir],
+        Ssh_authorized_key[$user],
+      ],
     }
 
     ::sshd::allow_from { 'sshd allow qualys from qualys appliance':


### PR DESCRIPTION
https://github.com/ncsa/puppet-profile_audit/issues/34

Change from UID/GID = 19999 because GID 19999 now exists in LDAP (as another group).

Use UID = 1125 to match LDAP and let the system choose the group's GID.